### PR TITLE
Fix typo in LAHS Schedule

### DIFF
--- a/lahs/calendar.bell
+++ b/lahs/calendar.bell
@@ -310,4 +310,4 @@ Sat weekend
 10/28/2024 schedule-g # Homecoming Assembly
 10/31/2024 schedule-d # Homecoming Week
 11/01/2024 schedule-e # Homecoming Parade
-11/11/2024 holiday # Veteran's Day
+11/11/2024 holiday # Veterans Day


### PR DESCRIPTION
Fix typo: "Veteran's Day" -> "Veterans Day"