### PR TITLE
Fix naming for LAHS 2024 finals

### DIFF
--- a/lahs/calendar.bell
+++ b/lahs/calendar.bell
@@ -313,6 +313,6 @@ Sat weekend
 11/11/2024 holiday # Veterans Day
 11/25/2024-11/29/2024 holiday # Thanksgiving Break
 12/17/2024 schedule-a
-12/18/2024 finals-tue
-12/19/2024 finals-wed
-12/20/2024 finals-thu
+12/18/2024 finals-2024-wed
+12/19/2024 finals-2024-thu
+12/20/2024 finals-2024-fri

--- a/lahs/calendar.bell
+++ b/lahs/calendar.bell
@@ -313,6 +313,6 @@ Sat weekend
 11/11/2024 holiday # Veterans Day
 11/25/2024-11/29/2024 holiday # Thanksgiving Break
 12/17/2024 schedule-a
-12/18/2024 finals-tue # Wednesday Finals
-12/19/2024 finals-wed # Thursday Finals
-12/20/2024 finals-thu # Friday Finals
+12/18/2024 finals-day-1
+12/19/2024 finals-day-2
+12/20/2024 finals-day-3

--- a/lahs/schedules.bell
+++ b/lahs/schedules.bell
@@ -381,7 +381,7 @@
 14:06 {Period 6}
 15:06 Free
 
-* finals-2024-wed # Wednesday Finals
+* finals-day-1 # Finals Day 1
 8:30 {Period 1}
 10:30 Brunch
 10:43 Passing to {Period 6}
@@ -391,14 +391,14 @@
 13:37 {Period 7}
 15:37 Free
 
-* finals-2024-thu # Thursday Finals
+* finals-day-2 # Finals Day 2
 8:30 {Period 2}
 10:30 Brunch
 10:43 Passing to {Period 5}
 10:50 {Period 5}
 12:50 Free
 
-* finals-2024-fri # Friday Finals
+* finals-day-3 # Finals Day 3
 8:30 {Period 3}
 10:30 Brunch
 10:43 Passing to {Period 4}

--- a/lahs/schedules.bell
+++ b/lahs/schedules.bell
@@ -380,3 +380,27 @@
 13:59 Passing to {Period 6}
 14:06 {Period 6}
 15:06 Free
+
+* finals-2024-wed # Wednesday Finals
+8:30 {Period 1}
+10:30 Brunch
+10:43 Passing to {Period 6}
+10:50 {Period 6}
+12:50 Lunch
+13:30 Passing to {Period 7}
+13:37 {Period 7}
+15:37 Free
+
+* finals-2024-thu # Thursday Finals
+8:30 {Period 2}
+10:30 Brunch
+10:43 Passing to {Period 5}
+10:50 {Period 5}
+12:50 Free
+
+* finals-2024-fri # Friday Finals
+8:30 {Period 3}
+10:30 Brunch
+10:43 Passing to {Period 4}
+10:50 {Period 4}
+12:50 Free


### PR DESCRIPTION
Fix naming for LAHS 2024 finals
The current workaround to adding new schedules is just to use tues/wed/thurs. Fixed by adding new schedules for wed/thurs/fri